### PR TITLE
Update flag default values to true

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -11,8 +11,8 @@ import (
 )
 
 func main() {
-	migrate := flag.Bool("migrate", false, "Run database migrations")
-	seed := flag.Bool("seed", false, "Seed database with initial data")
+	migrate := flag.Bool("migrate", true, "Run database migrations")
+	seed := flag.Bool("seed", true, "Seed database with initial data")
 	flag.Parse()
 
 	err := utils.LoadEnv()


### PR DESCRIPTION
This PR updates the default values for the migrate and seed flags to `true` in `cmd/main.go`.

Changes made:
- Changed `migrate` flag default value from `false` to `true`
- Changed `seed` flag default value from `false` to `true`

This means that when running the application without explicitly setting these flags, both database migrations and seeding will run by default.